### PR TITLE
ENH Stack tqdm progress bars when using --parallel

### DIFF
--- a/autoflatten/backends/pyflatten.py
+++ b/autoflatten/backends/pyflatten.py
@@ -60,6 +60,7 @@ class PyflattenBackend(FlattenBackend):
         config_path: Optional[str] = None,
         n_jobs: int = -1,
         cache_distances: bool = False,
+        tqdm_position: int = 0,
         **kwargs,
     ) -> str:
         """Flatten a cortical surface patch using pyflatten.
@@ -90,6 +91,8 @@ class PyflattenBackend(FlattenBackend):
             Number of parallel jobs (-1 = use all CPUs)
         cache_distances : bool
             Whether to cache computed k-ring distances
+        tqdm_position : int
+            Position of tqdm progress bar (for stacking bars in parallel execution)
         **kwargs
             Additional arguments (ignored)
 
@@ -156,7 +159,9 @@ class PyflattenBackend(FlattenBackend):
             if cache_distances:
                 cache_path = get_kring_cache_filename(output_path, config.kring)
 
-            flattener.compute_kring_distances(cache_path=cache_path)
+            flattener.compute_kring_distances(
+                cache_path=cache_path, tqdm_position=tqdm_position
+            )
 
             # Prepare optimization
             flattener.prepare_optimization()

--- a/autoflatten/cli.py
+++ b/autoflatten/cli.py
@@ -600,9 +600,9 @@ def cmd_run_full_pipeline(args):
                     args.backend,
                     True,  # verbose
                     run_plot,
-                    **backend_kwargs,
+                    **{**backend_kwargs, "tqdm_position": idx},
                 ): hemi
-                for hemi in hemispheres
+                for idx, hemi in enumerate(hemispheres)
             }
             for future in future_to_hemi:
                 hemi = future_to_hemi[future]

--- a/autoflatten/flatten/algorithm.py
+++ b/autoflatten/flatten/algorithm.py
@@ -1547,11 +1547,14 @@ class SurfaceFlattener:
         if self.config.verbose:
             print(f"Euler characteristic: {euler}, Boundary vertices: {len(boundary)}")
 
-    def compute_kring_distances(self, cache_path: Optional[str] = None) -> None:
+    def compute_kring_distances(
+        self, cache_path: Optional[str] = None, tqdm_position: int = 0
+    ) -> None:
         """Compute or load cached k-ring geodesic distances.
 
         Args:
             cache_path: Path to cache file. If None, no caching is performed.
+            tqdm_position: Position of tqdm progress bar (for stacking bars in parallel execution).
         """
         if self.fiducial_vertices is None:
             raise RuntimeError("Must call load_data before compute_kring_distances")
@@ -1573,7 +1576,10 @@ class SurfaceFlattener:
                         f"(all neighbors)..."
                     )
                 self.k_rings, self.target_distances = compute_kring_geodesic_distances(
-                    self.fiducial_vertices, self.faces, kring_config.k_ring
+                    self.fiducial_vertices,
+                    self.faces,
+                    kring_config.k_ring,
+                    tqdm_position=tqdm_position,
                 )
                 if cache_path:
                     if self.config.verbose:
@@ -1606,6 +1612,7 @@ class SurfaceFlattener:
                         self.faces,
                         kring_config.k_ring,
                         n_samples_per_ring=kring_config.n_neighbors_per_ring,
+                        tqdm_position=tqdm_position,
                     )
                 )
                 if cache_path:

--- a/autoflatten/flatten/distance.py
+++ b/autoflatten/flatten/distance.py
@@ -507,7 +507,7 @@ def compute_graph_distance(graph, source_idx, k_ring, correction=None):
 
 
 def compute_kring_geodesic_distances(
-    vertices, faces, k, correction=None, use_numba=True, n_threads=None
+    vertices, faces, k, correction=None, use_numba=True, n_threads=None, tqdm_position=0
 ):
     """Compute geodesic distances from each vertex to its k-ring neighbors.
 
@@ -530,6 +530,8 @@ def compute_kring_geodesic_distances(
         If True (default), use Numba-accelerated implementations
     n_threads : int, optional
         Number of threads for parallel k-ring computation
+    tqdm_position : int, optional
+        Position of tqdm progress bar (for stacking bars in parallel execution)
 
     Returns
     -------
@@ -563,12 +565,22 @@ def compute_kring_geodesic_distances(
             _limited_dijkstra_numba(
                 graph.indptr, graph.indices, graph.data, v, k_rings[v], correction
             )
-            for v in tqdm(range(n_vertices), desc="Computing k-ring distances")
+            for v in tqdm(
+                range(n_vertices),
+                desc="Computing k-ring distances",
+                position=tqdm_position,
+                leave=True,
+            )
         ]
     else:
         distances = [
             _limited_dijkstra(v, k_rings[v], graph, correction)
-            for v in tqdm(range(n_vertices), desc="Computing k-ring distances")
+            for v in tqdm(
+                range(n_vertices),
+                desc="Computing k-ring distances",
+                position=tqdm_position,
+                leave=True,
+            )
         ]
 
     return k_rings, distances
@@ -901,6 +913,7 @@ def compute_kring_geodesic_distances_angular(
     correction=None,
     use_numba=True,
     n_threads=None,
+    tqdm_position=0,
 ):
     """Compute geodesic distances with angular sampling at each ring.
 
@@ -924,6 +937,8 @@ def compute_kring_geodesic_distances_angular(
         If True (default), use Numba-accelerated Dijkstra
     n_threads : int, optional
         Number of threads for Numba
+    tqdm_position : int, optional
+        Position of tqdm progress bar (for stacking bars in parallel execution)
 
     Returns
     -------
@@ -960,7 +975,9 @@ def compute_kring_geodesic_distances_angular(
     sampled_neighbors = []
     sampled_distances = []
 
-    for v in tqdm(range(n_vertices), desc="Sampling neighbors"):
+    for v in tqdm(
+        range(n_vertices), desc="Sampling neighbors", position=tqdm_position, leave=True
+    ):
         v_neighbors = []
 
         center = vertices[v]

--- a/examples/example_geodesic_refinement.py
+++ b/examples/example_geodesic_refinement.py
@@ -20,6 +20,7 @@ from autoflatten.core import (
 from autoflatten.utils import load_json
 from autoflatten.config import fsaverage_cut_template
 
+
 # Example 1: Basic usage with default fsaverage template
 def example_basic_refinement():
     """Basic example of geodesic refinement."""
@@ -35,7 +36,7 @@ def example_basic_refinement():
     prefix = f"{hemi}_"
     for key, value in template_data.items():
         if key.startswith(prefix):
-            new_key = key[len(prefix):]
+            new_key = key[len(prefix) :]
             vertex_dict[new_key] = np.array(value)
 
     # Map cuts to target subject
@@ -44,9 +45,7 @@ def example_basic_refinement():
 
     # Ensure continuity
     print("Ensuring continuous cuts...")
-    vertex_dict_fixed = ensure_continuous_cuts(
-        vertex_dict_mapped.copy(), subject, hemi
-    )
+    vertex_dict_fixed = ensure_continuous_cuts(vertex_dict_mapped.copy(), subject, hemi)
 
     # Apply geodesic refinement
     print("Refining cuts with geodesic shortest paths...")
@@ -64,7 +63,9 @@ def example_basic_refinement():
             before = len(vertex_dict_fixed[cut_name])
             after = len(vertex_dict_refined[cut_name])
             reduction = 100 * (1 - after / before)
-            print(f"{cut_name}: {before} → {after} vertices ({reduction:.1f}% reduction)")
+            print(
+                f"{cut_name}: {before} → {after} vertices ({reduction:.1f}% reduction)"
+            )
 
     return vertex_dict_refined
 
@@ -111,13 +112,11 @@ def example_compare_refinement(subject, hemi):
     prefix = f"{hemi}_"
     for key, value in template_data.items():
         if key.startswith(prefix):
-            new_key = key[len(prefix):]
+            new_key = key[len(prefix) :]
             vertex_dict[new_key] = np.array(value)
 
     vertex_dict_mapped = map_cuts_to_subject(vertex_dict, subject, hemi)
-    vertex_dict_fixed = ensure_continuous_cuts(
-        vertex_dict_mapped.copy(), subject, hemi
-    )
+    vertex_dict_fixed = ensure_continuous_cuts(vertex_dict_mapped.copy(), subject, hemi)
 
     # Apply refinement
     vertex_dict_refined = refine_cuts_with_geodesic(
@@ -168,7 +167,7 @@ def calculate_path_length(G, vertices):
     for i in range(len(vertices) - 1):
         v1, v2 = vertices[i], vertices[i + 1]
         if G.has_edge(v1, v2):
-            total_length += G[v1][v2]['weight']
+            total_length += G[v1][v2]["weight"]
     return total_length
 
 
@@ -192,6 +191,7 @@ if __name__ == "__main__":
     print("  python example_geodesic_refinement.py <subject_id> <hemi>")
 
     import sys
+
     if len(sys.argv) == 3:
         subject = sys.argv[1]
         hemi = sys.argv[2]


### PR DESCRIPTION
## Summary
- Add `tqdm_position` parameter through the call chain so that when running hemispheres in parallel, the progress bars are stacked on separate lines instead of overlapping
- Each hemisphere gets a unique position (0 for lh, 1 for rh) for its tqdm bar

## Test plan
- [x] All 120 existing tests pass
- [x] Manual test: run `autoflatten <subject> --parallel` and verify progress bars stack correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)