### PR TITLE
FIX Match FreeSurfer's exact initial projection algorithm

### DIFF
--- a/autoflatten/flatten/algorithm.py
+++ b/autoflatten/flatten/algorithm.py
@@ -359,7 +359,8 @@ def freesurfer_projection(vertices: np.ndarray, faces: np.ndarray) -> np.ndarray
     # igl.per_vertex_normals returns area-weighted average of adjacent face normals
     vertex_normals = igl.per_vertex_normals(vertices, faces)
 
-    # Step 2: Compute average normal (sum of vertex normals, magnitude doesn't matter)
+    # Step 2: Compute average normal (sum of vertex normals; direction matters for rotation,
+    # and the vector is normalized before use)
     avg_normal = vertex_normals.sum(axis=0)
 
     # Step 3 & 4: Center vertices at origin


### PR DESCRIPTION
## Summary
- Fixed initial projection to match FreeSurfer's MRISflattenPatch algorithm exactly
- Changed from area-weighted face normals to vertex normals
- Use FreeSurfer's transform() rotation matrix instead of Rodrigues' formula
- Removed post-hoc X-flip orientation fix that caused inconsistent hemisphere orientations

This fixes an issue where left hemisphere flatmaps appeared rotated 180 degrees compared to expected orientation.

## Test plan
- [x] All 156 existing tests pass
- [x] Verify LH and RH flatmaps now have consistent orientations matching FreeSurfer output

🤖 Generated with [Claude Code](https://claude.com/claude-code)