### PR TITLE
Restore @njit on _get_k_rings_numba (perf regression from #67)

### DIFF
--- a/autoflatten/flatten/distance.py
+++ b/autoflatten/flatten/distance.py
@@ -102,6 +102,7 @@ def get_k_ring(faces, n_vertices, k):
     return k_rings
 
 
+@njit(parallel=True, cache=True)
 def _get_k_rings_numba(adj_flat, adj_offsets, k):
     """Compute k-ring neighbors for all vertices in parallel using Numba.
 


### PR DESCRIPTION
`dev` already contains the dead-code cleanup (#67), and that cleanup **accidentally dropped the `@njit(parallel=True, cache=True)` decorator** from the live, performance-critical `_get_k_rings_numba`. Without it the k-ring builder runs as interpreted serial Python (`prange` falls back to `range`) — a silent ~20x regression on standard meshes.

This restores the decorator. No output change. Caught by Gemini code review + a comprehensive review.

Targets `dev`. The flatten performance/fidelity improvements (#70) build on top of this.