### PR TITLE
Default projection to continuity-only (geodesic refinement off)

### DIFF
--- a/autoflatten/cli.py
+++ b/autoflatten/cli.py
@@ -175,7 +175,7 @@ def run_projection(
     output_dir,
     template_file=None,
     overwrite=False,
-    refine_geodesic=True,
+    refine_geodesic=False,
     verbose=True,
 ):
     """
@@ -302,7 +302,9 @@ def run_projection(
         else:
             print("\nGeodesic Refinement")
             print("-" * 19)
-            print("Skipped (--no-refine-geodesic)")
+            print(
+                "Skipped (continuity-only is the default; use --refine-geodesic to enable)"
+            )
 
         # Get subject surface data
         print("\nPatch Creation")
@@ -442,7 +444,7 @@ def process_hemisphere(
     template_file=None,
     run_flatten=True,
     overwrite=False,
-    refine_geodesic=True,
+    refine_geodesic=False,
     backend=None,
     verbose=True,
     run_plot=True,
@@ -665,7 +667,7 @@ def cmd_run_full_pipeline(args):
                     args.template_file,
                     True,  # run_flatten
                     args.overwrite,
-                    not args.no_refine_geodesic,
+                    args.refine_geodesic,
                     args.backend,
                     True,  # verbose
                     True,  # run_plot
@@ -691,7 +693,7 @@ def cmd_run_full_pipeline(args):
                     args.template_file,
                     True,  # run_flatten
                     args.overwrite,
-                    not args.no_refine_geodesic,
+                    args.refine_geodesic,
                     args.backend,
                     True,  # verbose
                     True,  # run_plot
@@ -757,7 +759,7 @@ def cmd_project(args):
                 output_dir=output_dir,
                 template_file=args.template_file,
                 overwrite=args.overwrite,
-                refine_geodesic=not args.no_refine_geodesic,
+                refine_geodesic=args.refine_geodesic,
                 verbose=True,
             )
             results[hemi] = patch_file
@@ -1010,9 +1012,10 @@ def add_projection_args(parser):
         help="Path to custom JSON template file defining cuts",
     )
     parser.add_argument(
-        "--no-refine-geodesic",
+        "--refine-geodesic",
         action="store_true",
-        help="Disable geodesic refinement of projected cuts",
+        help="Enable geodesic refinement of projected cuts (off by default; the "
+        "shipped pipeline is continuity-only, which gives lower distortion)",
     )
 
 

--- a/autoflatten/tests/test_cli.py
+++ b/autoflatten/tests/test_cli.py
@@ -71,13 +71,13 @@ class TestArgumentParsers:
             parser.parse_args(["--hemispheres", "invalid"])
 
     def test_add_projection_args(self):
-        """add_projection_args should add template-file and no-refine-geodesic."""
+        """add_projection_args should add template-file and refine-geodesic (off by default)."""
         parser = argparse.ArgumentParser()
         add_projection_args(parser)
 
         args = parser.parse_args([])
         assert args.template_file is None
-        assert args.no_refine_geodesic is False
+        assert args.refine_geodesic is False
 
     def test_add_projection_args_with_values(self):
         """add_projection_args arguments should accept values."""
@@ -85,10 +85,10 @@ class TestArgumentParsers:
         add_projection_args(parser)
 
         args = parser.parse_args(
-            ["--template-file", "/path/to/template.json", "--no-refine-geodesic"]
+            ["--template-file", "/path/to/template.json", "--refine-geodesic"]
         )
         assert args.template_file == "/path/to/template.json"
-        assert args.no_refine_geodesic is True
+        assert args.refine_geodesic is True
 
     def test_add_backend_args(self):
         """add_backend_args should add backend choice with pyflatten default."""
@@ -564,7 +564,7 @@ class TestMainFunction:
                 str(subject_dir),
                 "--hemispheres",
                 "lh",
-                "--no-refine-geodesic",
+                "--refine-geodesic",
             ],
         ):
             # Mock the project command to avoid running it
@@ -576,4 +576,4 @@ class TestMainFunction:
                 args = mock_project.call_args[0][0]
                 assert args.subject_dir == str(subject_dir)
                 assert args.hemispheres == "lh"
-                assert args.no_refine_geodesic is True
+                assert args.refine_geodesic is True


### PR DESCRIPTION
## Default projection to continuity-only (geodesic cut refinement off)

The benchmark refinement ablation (FINDINGS §15) showed that **geodesic cut refinement raises metric distortion** — `continuity_only` (connect cut components without thinning them along geodesics) beats the geodesic-refined pipeline by ~0.28 pp distortion with fewer flips on 4/6 hemispheres. This makes continuity-only the better shipped default.

### Changes (package only, 2 files)
- `cli.py`: replace `--no-refine-geodesic` with an **opt-in `--refine-geodesic`** (default off); flip the `run_projection` / `process_hemisphere` `refine_geodesic` defaults to `False`.
- `tests/test_cli.py`: updated for the new flag. 34 CLI tests pass.

### Notes
- Behavior change: `autoflatten project <subject>` now skips geodesic refinement by default; pass `--refine-geodesic` to restore the old behavior.
- Split out of the paper-benchmark PR (#71) so the package default change can be reviewed/merged on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
